### PR TITLE
Added VS2022 build dependencies batch files

### DIFF
--- a/universal/build_deps_msvc2022_32.bat
+++ b/universal/build_deps_msvc2022_32.bat
@@ -1,7 +1,7 @@
 setlocal
 set output=%cd%\allegro_deps-msvc2022-x86\allegro_deps
 set generator=-G "Visual Studio 17 2022" -A Win32
-set toolchain=-T v141_xp
+set toolchain=-T v143
 set build_dir=%cd%\build_msvc2022_32
 
 call build_deps_msvc.bat

--- a/universal/build_deps_msvc2022_32.bat
+++ b/universal/build_deps_msvc2022_32.bat
@@ -1,0 +1,7 @@
+setlocal
+set output=%cd%\allegro_deps-msvc2022-x86\allegro_deps
+set generator=-G "Visual Studio 17 2022" -A Win32
+set toolchain=-T v141_xp
+set build_dir=%cd%\build_msvc2022_32
+
+call build_deps_msvc.bat

--- a/universal/build_deps_msvc2022_64.bat
+++ b/universal/build_deps_msvc2022_64.bat
@@ -1,0 +1,7 @@
+setlocal
+set output=%cd%\allegro_deps-msvc2022-x64\allegro_deps
+set generator=-G "Visual Studio 17 2022" -A x64
+set toolchain=-T v141_xp
+set build_dir=%cd%\build_msvc2022_64
+
+call build_deps_msvc.bat

--- a/universal/build_deps_msvc2022_64.bat
+++ b/universal/build_deps_msvc2022_64.bat
@@ -1,7 +1,7 @@
 setlocal
 set output=%cd%\allegro_deps-msvc2022-x64\allegro_deps
 set generator=-G "Visual Studio 17 2022" -A x64
-set toolchain=-T v141_xp
+set toolchain=-T v143
 set build_dir=%cd%\build_msvc2022_64
 
 call build_deps_msvc.bat


### PR DESCRIPTION
Added batch files with the specific generator for Visual Studio 2022.
Should the toolchain be v143 (new with VS2022)? Toolchain version v141_xp is now depracated in the VS2022 installer.