### PR TITLE
allegro build scripts for visual studio 2022

### DIFF
--- a/universal/build_allegro_msvc2022_32.bat
+++ b/universal/build_allegro_msvc2022_32.bat
@@ -1,0 +1,8 @@
+setlocal
+set deps=%cd%\allegro_deps-msvc2022-x86\allegro_deps
+set output=%cd%\allegro-msvc2022-x86\allegro
+set generator=-G "Visual Studio 17 2022" -A Win32
+set toolchain=-T v143
+set build_dir=%cd%\build_msvc2022_32
+
+call build_allegro_msvc.bat

--- a/universal/build_allegro_msvc2022_64.bat
+++ b/universal/build_allegro_msvc2022_64.bat
@@ -1,0 +1,8 @@
+setlocal
+set deps=%cd%\allegro_deps-msvc2022-x64\allegro_deps
+set output=%cd%\allegro-msvc2022-x64\allegro
+set generator=-G "Visual Studio 17 2022" -A x64
+set toolchain=-T v143
+set build_dir=%cd%\build_msvc2022_64
+
+call build_allegro_msvc.bat


### PR DESCRIPTION
Closes #13 
Here are the missing supporting scripts for the VS 2022. I built allegro locally with both of them.